### PR TITLE
Refactor into modular monitor package

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,15 +1,10 @@
+"""Entry point for the UPS monitoring application."""
+
 import asyncio
-import subprocess
-import socket
-from flask import Flask, render_template, request, jsonify
-from flask_socketio import SocketIO
-import pysnmp.hlapi.asyncio as snmp
 
-# Configuración inicial
-app = Flask(__name__)
-socketio = SocketIO(app, async_mode='eventlet')
+from monitor.web import create_app
+from monitor.ups import monitor_ups
 
-# Configuración
 UPS_IPS = [
     {"ip": "10.104.154.136", "name": "UPS falsa"},
     {"ip": "10.105.37.27", "name": "UPS c20"},
@@ -21,128 +16,13 @@ UPS_IPS = [
     {"ip": "10.105.35.140", "name": "b06"},
 ]
 
-SNMP_COMMUNITY = "speyburn"
-MAX_LATENCY_DISCONNECTED = 60  # Latencia máxima para marcar desconectado
+MAX_LATENCY_DISCONNECTED = 60  # Latency threshold for disconnect status
+DATA = {}
 
-DATA = {}  # Global dictionary to store UPS data
+app, socketio = create_app(UPS_IPS, DATA)
 
-# Consultar SNMP de forma asíncrona
-async def snmp_query(ip, oid):
-    try:
-        iterator = snmp.getCmd(
-            snmp.SnmpEngine(),
-            snmp.CommunityData("public"),
-            snmp.UdpTransportTarget((ip, 161)),
-            snmp.ContextData(),
-            snmp.ObjectType(snmp.ObjectIdentity(oid))
-        )
-        errorIndication, errorStatus, errorIndex, varBinds = await iterator
 
-        if errorIndication:
-            return "Error"
-        elif errorStatus:
-            return "Error"
-        else:
-            for varBind in varBinds:
-                return str(varBind[1])
-    except Exception as e:
-        return "Error"
-
-# Función para hacer ping y verificar el puerto HTTPS
-async def ping_and_https_check(ip):
-    result = {"ping_response": "No respondido", "https_check": "No verificado", "latency": None}
-    try:
-        ping_output = await asyncio.create_subprocess_exec(
-            "ping", "-c", "1", "-W", "1", ip,
-            stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
-        )
-        stdout, stderr = await ping_output.communicate()
-
-        if ping_output.returncode == 0:
-            latency = float(stdout.decode().split("time=")[1].split("ms")[0])
-            result["latency"] = latency
-            result["ping_response"] = "Ping exitoso" if latency < MAX_LATENCY_DISCONNECTED else "Alta latencia"
-        else:
-            result["ping_response"] = "Ping fallido"
-    except Exception:
-        result["ping_response"] = "Ping fallido"
-
-    try:
-        with socket.create_connection((ip, 443), timeout=1):
-            result["https_check"] = "Puerto HTTPS abierto"
-    except socket.error:
-        result["https_check"] = "Puerto HTTPS cerrado"
-
-    return result
-
-# Monitorear una UPS
-async def monitor_single_ups(ups):
-    result = {
-        "ip": ups["ip"],
-        "name": ups["name"],
-        "status": "Desconectada",
-        "latency": None,
-        "battery_voltage": "N/A",
-        "input_voltage": "N/A",
-        "output_voltage": "N/A",
-        "temperature": "N/A",
-        "ping_response": "No respondido",
-        "https_check": "No verificado"
-    }
-
-    try:
-        # Realizar consultas concurrentes
-        ping_result = await ping_and_https_check(ups["ip"])
-        snmp_tasks = {
-            "battery_voltage": snmp_query(ups["ip"], ".1.3.6.1.2.1.33.1.2.4.0"),
-            "input_voltage": snmp_query(ups["ip"], ".1.3.6.1.2.1.33.1.2.5.0"),
-            "output_voltage": snmp_query(ups["ip"], ".1.3.6.1.4.1.318.1.4.2.2.1.3.1"),
-            "temperature": snmp_query(ups["ip"], ".1.3.6.1.2.1.33.1.2.7.0")
-        }
-
-        snmp_results = await asyncio.gather(*snmp_tasks.values(), return_exceptions=True)
-
-        # Actualizar resultados
-        result.update(ping_result)
-        result["battery_voltage"] = snmp_results[0]
-        result["input_voltage"] = snmp_results[1]
-        result["output_voltage"] = snmp_results[2]
-        result["temperature"] = snmp_results[3]
-
-        if result["ping_response"] == "Ping exitoso":
-            result["status"] = "Conectada"
-    except Exception as e:
-        result["status"] = f"Error: {e}"
-
-    return result
-
-# Monitorear todas las UPS
-async def monitor_ups():
-    global DATA
-    while True:
-        tasks = [monitor_single_ups(ups) for ups in UPS_IPS]
-        results = await asyncio.gather(*tasks)
-        DATA = {res["ip"]: res for res in results}
-        socketio.emit("update_data", DATA)
-        await asyncio.sleep(5)
-
-# Rutas de Flask
-@app.route("/")
-def index():
-    return render_template("index.html")
-
-@app.route("/add_ups", methods=["POST"])
-def add_ups():
-    data = request.json
-    UPS_IPS.append(data)
-    return jsonify({"status": "success", "message": "UPS agregada"})
-
-@app.route("/get_data", methods=["GET"])
-def get_data():
-    return jsonify(DATA)
-
-# Iniciar la aplicación
 if __name__ == "__main__":
     loop = asyncio.get_event_loop()
-    loop.create_task(monitor_ups())
+    loop.create_task(monitor_ups(UPS_IPS, DATA, socketio, MAX_LATENCY_DISCONNECTED))
     socketio.run(app, host="0.0.0.0", port=5000)

--- a/monitor/__init__.py
+++ b/monitor/__init__.py
@@ -1,0 +1,8 @@
+"""Monitoring utilities package."""
+
+__all__ = [
+    "snmp",
+    "network",
+    "web",
+    "ups",
+]

--- a/monitor/network.py
+++ b/monitor/network.py
@@ -1,0 +1,34 @@
+"""Network validation helpers."""
+
+import asyncio
+import socket
+
+async def ping_and_https_check(ip: str, max_latency: float = 60) -> dict:
+    """Ping the IP and verify that HTTPS port 443 is open.
+
+    Returns a dictionary with keys ``ping_response``, ``https_check`` and ``latency``.
+    """
+    result = {"ping_response": "No respondido", "https_check": "No verificado", "latency": None}
+    try:
+        ping_output = await asyncio.create_subprocess_exec(
+            "ping", "-c", "1", "-W", "1", ip,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, _ = await ping_output.communicate()
+        if ping_output.returncode == 0:
+            latency = float(stdout.decode().split("time=")[1].split("ms")[0])
+            result["latency"] = latency
+            result["ping_response"] = "Ping exitoso" if latency < max_latency else "Alta latencia"
+        else:
+            result["ping_response"] = "Ping fallido"
+    except Exception:
+        result["ping_response"] = "Ping fallido"
+
+    try:
+        with socket.create_connection((ip, 443), timeout=1):
+            result["https_check"] = "Puerto HTTPS abierto"
+    except socket.error:
+        result["https_check"] = "Puerto HTTPS cerrado"
+
+    return result

--- a/monitor/snmp.py
+++ b/monitor/snmp.py
@@ -1,0 +1,24 @@
+"""SNMP related helper functions."""
+
+import pysnmp.hlapi.asyncio as snmp
+
+async def snmp_query(ip: str, oid: str, community: str = "public") -> str:
+    """Perform an asynchronous SNMP GET request.
+
+    Returns the value as a string or ``"Error"`` if the query fails.
+    """
+    try:
+        iterator = snmp.getCmd(
+            snmp.SnmpEngine(),
+            snmp.CommunityData(community),
+            snmp.UdpTransportTarget((ip, 161)),
+            snmp.ContextData(),
+            snmp.ObjectType(snmp.ObjectIdentity(oid)),
+        )
+        errorIndication, errorStatus, errorIndex, varBinds = await iterator
+        if errorIndication or errorStatus:
+            return "Error"
+        for varBind in varBinds:
+            return str(varBind[1])
+    except Exception:
+        return "Error"

--- a/monitor/ups.py
+++ b/monitor/ups.py
@@ -1,0 +1,54 @@
+"""Asynchronous monitoring helpers for UPS devices."""
+
+import asyncio
+from typing import Dict, List
+
+from .network import ping_and_https_check
+from .snmp import snmp_query
+
+
+async def monitor_single_ups(ups: Dict[str, str], max_latency: float) -> Dict[str, str]:
+    """Monitor a single UPS returning a dictionary of metrics."""
+    result = {
+        "ip": ups["ip"],
+        "name": ups["name"],
+        "status": "Desconectada",
+        "latency": None,
+        "battery_voltage": "N/A",
+        "input_voltage": "N/A",
+        "output_voltage": "N/A",
+        "temperature": "N/A",
+        "ping_response": "No respondido",
+        "https_check": "No verificado",
+    }
+
+    try:
+        ping_result = await ping_and_https_check(ups["ip"], max_latency)
+        snmp_tasks = {
+            "battery_voltage": snmp_query(ups["ip"], ".1.3.6.1.2.1.33.1.2.4.0"),
+            "input_voltage": snmp_query(ups["ip"], ".1.3.6.1.2.1.33.1.2.5.0"),
+            "output_voltage": snmp_query(ups["ip"], ".1.3.6.1.4.1.318.1.4.2.2.1.3.1"),
+            "temperature": snmp_query(ups["ip"], ".1.3.6.1.2.1.33.1.2.7.0"),
+        }
+        snmp_results = await asyncio.gather(*snmp_tasks.values(), return_exceptions=True)
+        result.update(ping_result)
+        result["battery_voltage"] = snmp_results[0]
+        result["input_voltage"] = snmp_results[1]
+        result["output_voltage"] = snmp_results[2]
+        result["temperature"] = snmp_results[3]
+        if result["ping_response"] == "Ping exitoso":
+            result["status"] = "Conectada"
+    except Exception as e:
+        result["status"] = f"Error: {e}"
+    return result
+
+
+async def monitor_ups(ups_list: List[Dict[str, str]], data_store: Dict[str, Dict[str, str]], socketio, max_latency: float) -> None:
+    """Continuously monitor all UPS devices and emit updates via Socket.IO."""
+    while True:
+        tasks = [monitor_single_ups(ups, max_latency) for ups in ups_list]
+        results = await asyncio.gather(*tasks)
+        data_store.clear()
+        data_store.update({res["ip"]: res for res in results})
+        socketio.emit("update_data", data_store)
+        await asyncio.sleep(5)

--- a/monitor/web.py
+++ b/monitor/web.py
@@ -1,0 +1,26 @@
+"""Flask web application and routes."""
+
+from flask import Flask, render_template, request, jsonify
+from flask_socketio import SocketIO
+
+
+def create_app(ups_list, data_store):
+    """Create the Flask application and register routes."""
+    app = Flask(__name__)
+    socketio = SocketIO(app, async_mode="eventlet")
+
+    @app.route("/")
+    def index():
+        return render_template("index.html")
+
+    @app.route("/add_ups", methods=["POST"])
+    def add_ups():
+        data = request.json
+        ups_list.append(data)
+        return jsonify({"status": "success", "message": "UPS agregada"})
+
+    @app.route("/get_data", methods=["GET"])
+    def get_data():
+        return jsonify(data_store)
+
+    return app, socketio


### PR DESCRIPTION
## Summary
- Split monolithic logic into monitor package with snmp, network, web, and ups modules
- Simplify main script to only initialize configuration and run monitor

## Testing
- `python -m py_compile main.py monitor/*.py`
- `timeout 5 python main.py` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pip install flask flask-socketio eventlet pysnmp` *(fails: Could not find a version that satisfies the requirement flask)*

------
https://chatgpt.com/codex/tasks/task_e_689dec14283883239e0a55dd4237c044